### PR TITLE
dhcp-server: fix typo in lookup of vacant address

### DIFF
--- a/lrndis/dhcp-server/dhserver.c
+++ b/lrndis/dhcp-server/dhserver.c
@@ -124,7 +124,7 @@ static dhcp_entry_t *vacant_address()
 	int i;
 	for (i = 0; i < config->num_entry; i++)
 		if (is_vacant(config->entries + i))
-			return config->entries + 1;
+			return config->entries + i;
 	return NULL;
 }
 


### PR DESCRIPTION
Hi! Thanks for providing this nice demo and the included dhcp-server. I've used it with lwIP/FreeRTOS. While connections from smartphone worked, it didn't from my Mac. While single stepping, something didn't sum up and looking at vacant_address(), it looks like this is a typo. 
After fixing it, the Mac could connect without problems.